### PR TITLE
Kafka role improvements

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,14 +1,21 @@
 ---
 
+kafka_path                        : "/opt/kafka_{{ kafka_scala_version }}-{{ kafka_version }}"
+kafka_hosts                       : "{{ groups['bi-kafka'] }}"
+kafka_zookeeper_hosts             : "{{ groups['bi-zookeeper'] }}"
+kafka_zookeeper_chroot            : "/bi-kafka"
+kafka_version                     : "0.9.0.0"
+kafka_scala_version               : "2.11"
+kafka_zookeeper_port              : 2181
+
 kafka:
   apache_mirror: http://apache.mirror.anlx.net/
   auto_create_topics: "false"
-  conf_dir: /home/kafka/etc
-  data_dir: /home/kafka/data
+  conf_dir: "{{ kafka_path }}/config"
+  data_dir: "{{ kafka_path }}/data"
   group: kafka
   heap_opts: "-Xmx{{ (ansible_memtotal_mb / 2) | int }}m -Xms{{ (ansible_memtotal_mb / 2) | int }}m"
-  hosts:
-    - localhost
+  hosts: "{{ kafka_hosts }}"
   log_cleanup_interval_mins: 1
   log_dir: /home/kafka/log
   log_flush_interval_messages: 10000
@@ -29,10 +36,9 @@ kafka:
   upstart_conf: /etc/init/kafka.conf
   use_systemd: no
   user: kafka
-  version_kafka: "0.9.0.0"
-  version_scala: "2.11"
+  version_kafka: "{{ kafka_version }}"
+  version_scala: "{{ kafka_scala_version }}"
   zookeeper_connection_timeout_ms: 1000000
-  zookeeper_hosts:
-    - localhost
-  zookeeper_chroot: /
-  zookeeper_port: 2181
+  zookeeper_hosts: "{{ kafka_zookeeper_hosts }}"
+  zookeeper_chroot: "{{ kafka_zookeeper_chroot }}"
+  zookeeper_port: "{{ kafka_zookeeper_port }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,12 +12,12 @@ kafka:
   apache_mirror: http://apache.mirror.anlx.net/
   auto_create_topics: "false"
   conf_dir: "{{ kafka_path }}/config"
-  data_dir: "{{ kafka_path }}/data"
+  data_dir: "/var/kafka/data"
   group: kafka
   heap_opts: "-Xmx{{ (ansible_memtotal_mb / 2) | int }}m -Xms{{ (ansible_memtotal_mb / 2) | int }}m"
   hosts: "{{ kafka_hosts }}"
   log_cleanup_interval_mins: 1
-  log_dir: /home/kafka/log
+  log_dir: /var/log/kafka
   log_flush_interval_messages: 10000
   log_flush_interval_ms: 1000
   log_level: WARN

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,3 +34,5 @@ kafka:
   zookeeper_connection_timeout_ms: 1000000
   zookeeper_hosts:
     - localhost
+  zookeeper_chroot: /
+  zookeeper_port: 2181

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 
 kafka_path                        : "/opt/kafka_{{ kafka_scala_version }}-{{ kafka_version }}"
-kafka_hosts                       : "{{ groups['bi-kafka'] }}"
-kafka_zookeeper_hosts             : "{{ groups['bi-zookeeper'] }}"
-kafka_zookeeper_chroot            : "/bi-kafka"
+kafka_hosts                       : []
+kafka_zookeeper_hosts             : []
+kafka_zookeeper_chroot            : "/"
 kafka_version                     : "0.9.0.0"
 kafka_scala_version               : "2.11"
 kafka_zookeeper_port              : 2181

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -16,6 +16,15 @@
     - "/home/{{ kafka.user }}/log"
     - "/home/{{ kafka.user }}/data"
 
+- name: Create /opt path
+  become: yes
+  file:
+    state: directory
+    path: "{{ item }}"
+    owner: "{{ kafka.user }}"
+  with_items:
+    - "/opt/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}/"
+
 - name: Remove lost+found in the datadir
   become: yes
   file:
@@ -34,17 +43,8 @@
   become_user: "{{ kafka.user }}"
   unarchive:
     copy: no
-    creates: "/home/{{ kafka.user }}/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}"
-    dest: "/home/{{ kafka.user }}"
+    dest: "/opt/"
     src: "/home/{{ kafka.user }}/tmp/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}.tgz"
-
-- name: Link kafka to the right version
-  become: yes
-  become_user: "{{ kafka.user }}"
-  file:
-    path: "/home/{{ kafka.user }}/kafka"
-    src: "/home/{{ kafka.user }}/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}"
-    state: link
 
 - name: link config dir
   become: yes
@@ -52,5 +52,5 @@
   file:
     force: yes
     path: "/home/{{ kafka.user }}/etc"
-    src: "/home/{{ kafka.user }}/kafka/config"
+    src: "/opt/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}/config"
     state: link

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -40,7 +40,7 @@
     group: "{{ kafka.user }}"
   with_items:
     - "{{ kafka.log_dir }}"
-    - "{{ kafka.data_dir }}/data"
+    - "{{ kafka.data_dir }}"
 
 - name: Remove lost+found in the datadir
   become: yes

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -13,23 +13,6 @@
     path: "{{ item }}"
   with_items:
     - "/home/{{ kafka.user }}/tmp"
-    - "/home/{{ kafka.user }}/log"
-    - "/home/{{ kafka.user }}/data"
-
-- name: Create /opt path
-  become: yes
-  file:
-    state: directory
-    path: "{{ item }}"
-    owner: "{{ kafka.user }}"
-  with_items:
-    - "/opt/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}/"
-
-- name: Remove lost+found in the datadir
-  become: yes
-  file:
-    path: "/home/{{ kafka.user }}/data/lost+found"
-    state: absent
 
 - name: Fetch kafka binary package
   become: yes
@@ -40,17 +23,27 @@
 
 - name: Uncompress the kafka tar
   become: yes
-  become_user: "{{ kafka.user }}"
   unarchive:
     copy: no
+    group: "{{ kafka.user }}"
+    owner: "{{ kafka.user }}"
+    creates: "/opt/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}"
     dest: "/opt/"
     src: "/home/{{ kafka.user }}/tmp/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}.tgz"
 
-- name: link config dir
+- name: Create data & log paths
   become: yes
-  become_user: "{{ kafka.user }}"
   file:
-    force: yes
-    path: "/home/{{ kafka.user }}/etc"
-    src: "/opt/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}/config"
-    state: link
+    state: directory
+    path: "{{ item }}"
+    owner: "{{ kafka.user }}"
+    group: "{{ kafka.user }}"
+  with_items:
+    - "{{ kafka_path }}/log"
+    - "{{ kafka_path }}/data"
+
+- name: Remove lost+found in the datadir
+  become: yes
+  file:
+    path: "{{ kafka_path }}/data/lost+found"
+    state: absent

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -39,8 +39,8 @@
     owner: "{{ kafka.user }}"
     group: "{{ kafka.user }}"
   with_items:
-    - "{{ kafka_path }}/log"
-    - "{{ kafka_path }}/data"
+    - "{{ kafka.log_dir }}"
+    - "{{ kafka.data_dir }}/data"
 
 - name: Remove lost+found in the datadir
   become: yes

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,18 +1,9 @@
 ---
 
-# Needed to ensure some services start properly
-- name: Set hostname
-  become: yes
-  lineinfile:
-    dest: /etc/hosts
-    line: "127.0.0.1 {{ ansible_hostname }}"
-  notify:
-    - restart kafka
-
 - name: Overwrite the start script so the Java Opts can be changed if Kafka 0.8.1.1
   become: yes
   lineinfile:
-    dest: "/opt/kafka_2.9.2-{{ kafka.version_kafka }}/bin/kafka-server-start.sh"
+    dest: "{{ kafka_path }}/bin/kafka-server-start.sh"
     regexp: "^export KAFKA_HEAP_OPTS="
     line: "export KAFKA_HEAP_OPTS=\"{{ kafka.heap_opts }}\""
   notify:
@@ -52,7 +43,7 @@
   become: yes
   become_user: "{{ kafka.user }}"
   template:
-    dest: "/opt/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}/config/log4j.properties"
+    dest: "{{ kafka_path }}/config/log4j.properties"
     mode: 0644
     src: log4j.properties.j2
   notify:
@@ -62,7 +53,7 @@
   become: yes
   become_user: "{{ kafka.user }}"
   template:
-    dest: "/opt/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}/config/server.properties"
+    dest: "{{ kafka_path }}/config/server.properties"
     mode: 0640
     src: server.properties.j2
   notify:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -52,7 +52,7 @@
   become: yes
   become_user: "{{ kafka.user }}"
   template:
-    dest: "/home/{{ kafka.user }}/etc/log4j.properties"
+    dest: "/opt/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}/config/log4j.properties"
     mode: 0644
     src: log4j.properties.j2
   notify:
@@ -62,7 +62,7 @@
   become: yes
   become_user: "{{ kafka.user }}"
   template:
-    dest: "/home/{{ kafka.user }}/etc/server.properties"
+    dest: "/opt/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}/config/server.properties"
     mode: 0640
     src: server.properties.j2
   notify:

--- a/templates/kafka.conf.j2
+++ b/templates/kafka.conf.j2
@@ -10,5 +10,5 @@ limit nofile 32768 32768
 # Rather than using setuid/setgid sudo is used because the pre-start task must run as root
 exec sudo -Hu {{ kafka.user }} -g {{ kafka.group }} \
     KAFKA_HEAP_OPTS="{{ kafka.heap_opts }}" \
-    /opt/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}/bin/kafka-server-start.sh \
-    /opt/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}/config/server.properties
+    {{ kafka_path }}/bin/kafka-server-start.sh \
+    {{ kafka_path }}/config/server.properties

--- a/templates/kafka.conf.j2
+++ b/templates/kafka.conf.j2
@@ -10,5 +10,5 @@ limit nofile 32768 32768
 # Rather than using setuid/setgid sudo is used because the pre-start task must run as root
 exec sudo -Hu {{ kafka.user }} -g {{ kafka.group }} \
     KAFKA_HEAP_OPTS="{{ kafka.heap_opts }}" \
-    /home/{{ kafka.user }}/kafka/bin/kafka-server-start.sh \
-    /home/{{ kafka.user }}/kafka/config/server.properties
+    /opt/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}/bin/kafka-server-start.sh \
+    /opt/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}/config/server.properties

--- a/templates/kafka.service.j2
+++ b/templates/kafka.service.j2
@@ -9,7 +9,7 @@ Group=kafka
 LimitNOFILE=32768
 Restart=on-failure
 Environment="KAFKA_HEAP_OPTS={{ kafka_heap_opts }}"
-ExecStart=/opt/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}/bin/kafka-server-start.sh /etc/kafka/server.properties
+ExecStart={{ kafka_path }}/bin/kafka-server-start.sh /etc/kafka/server.properties
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/kafka.service.j2
+++ b/templates/kafka.service.j2
@@ -9,7 +9,7 @@ Group=kafka
 LimitNOFILE=32768
 Restart=on-failure
 Environment="KAFKA_HEAP_OPTS={{ kafka_heap_opts }}"
-ExecStart=/opt/kafka/bin/kafka-server-start.sh /etc/kafka/server.properties
+ExecStart=/opt/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}/bin/kafka-server-start.sh /etc/kafka/server.properties
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/server.properties.j2
+++ b/templates/server.properties.j2
@@ -5,15 +5,14 @@
 # Server Basics
 # The id of the broker. This must be set to a unique integer for each broker.
 {% for url in kafka.hosts %}
-  {%- set url_host = url.split(':')[0] -%}
-  {%- if url_host == ansible_fqdn or url_host in ansible_all_ipv4_addresses
+  {%- if url == ansible_fqdn or url in ansible_all_ipv4_addresses
          or ( kafka.id is defined and loop.index0 == kafka.id | int ) -%}
 broker.id={{ loop.index0 }}
 
 ############################# Socket Server Settings #############################
 
 # The port the socket server listens on
-port={{ url.split(':')[1] }}
+port={{ kafka.port }}
   {% endif %}
 {% endfor %}
 
@@ -99,7 +98,7 @@ log.cleaner.enable=false
 # server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
 # You can also append an optional chroot string to the urls to specify the
 # root directory for all kafka znodes.
-zookeeper.connect={{ kafka.zookeeper_hosts | join(',') }}
+zookeeper.connect={{ kafka.zookeeper_hosts | join(":{0},".format(kafka.zookeeper_port)) }}:{{ kafka.zookeeper_port }}{{ kafka.zookeeper_chroot }}
 
 # Timeout in ms for connecting to zookeeper
 zookeeper.connection.timeout.ms={{ kafka.zookeeper_connection_timeout_ms }}


### PR DESCRIPTION
1. Improved management of vars
2. Allow defining zookeeper chroot for kafka
3. Place kafka in `/opt` as recommended instead of using the home directory.
4. Small improvements.
